### PR TITLE
fix duplicate function names in routers and error handler

### DIFF
--- a/src/app/core/router.py
+++ b/src/app/core/router.py
@@ -11,19 +11,19 @@ core = APIRouter()
 
 
 @core.get("/health", response_model=HealthCheckResponse)
-def health(request: Request) -> HealthCheckResponse:
+def health_get(request: Request) -> HealthCheckResponse:
     logger.debug(f"Methode: {request.method} on {request.url.path}")
     return {"version": request.app.state.VERSION, "timestamp": time()}
 
 
 @core.post("/health", response_model=HealthCheckResponse)
-def health(request: Request) -> HealthCheckResponse:
+def health_post(request: Request) -> HealthCheckResponse:
     logger.debug(f"Methode: {request.method} on {request.url.path}")
     return {"version": request.app.state.VERSION, "timestamp": time()}
 
 
 @core.websocket("/ws/health")
-async def health(websocket: WebSocket) -> None:
+async def health_ws(websocket: WebSocket) -> None:
     await websocket.accept()
     try:
         while True:

--- a/src/app/v1/errors.py
+++ b/src/app/v1/errors.py
@@ -8,7 +8,7 @@ class APIException(Exception):
 
 
 # @v1.exception_handler(APIException)
-def bad_request(request: Request, exc: APIException):
+def api_exception_handler(request: Request, exc: APIException):
     # logger.error(error.to_dict())
     return JSONResponse(
         status_code=418,

--- a/src/app/v1/router.py
+++ b/src/app/v1/router.py
@@ -11,19 +11,19 @@ v1 = APIRouter()
 
 
 @v1.get("/health", response_model=HealthCheckResponse)
-def health(request: Request) -> HealthCheckResponse:
+def health_get(request: Request) -> HealthCheckResponse:
     logger.debug(f"Methode: {request.method} on {request.url.path}")
     return {"version": request.app.state.VERSION, "timestamp": time()}
 
 
 @v1.post("/health", response_model=HealthCheckResponse)
-def health(request: Request) -> HealthCheckResponse:
+def health_post(request: Request) -> HealthCheckResponse:
     logger.debug(f"Methode: {request.method} on {request.url.path}")
     return {"version": request.app.state.VERSION, "timestamp": time()}
 
 
 @v1.websocket("/ws/health")
-async def health(websocket: WebSocket) -> None:
+async def health_ws(websocket: WebSocket) -> None:
     await websocket.accept()
     try:
         while True:


### PR DESCRIPTION
## Summary
- Rename the three `health` handlers in `core/router.py` and `v1/router.py` to `health_get` / `health_post` / `health_ws` so they no longer shadow each other in module scope.
- Rename the `APIException` JSONResponse handler in `v1/errors.py` from `bad_request` to `api_exception_handler` to disambiguate it from the `bad_request` HTTPException helper that previously overwrote it.

## Test plan
- [ ] Existing test suite passes
- [ ] `/health` GET, POST, and `/ws/health` endpoints respond as before on both routers

🤖 Generated with [Claude Code](https://claude.com/claude-code)