### PR TITLE
fix logger setup to use deployment CONFIG_NAME

### DIFF
--- a/src/app/logging.py
+++ b/src/app/logging.py
@@ -59,9 +59,9 @@ def setup_logger(config_name, json_serialize=True):
     for uvicorn_logger in loggers:
         uvicorn_logger.handlers = [intercept_handler]
 
-    if config_name == "prod":
+    if config_name == "PROD":
         service_log_level = logging.ERROR
-    elif config_name == "staging":
+    elif config_name == "STAGE":
         service_log_level = logging.INFO
     else:
         service_log_level = logging.DEBUG

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -51,5 +51,5 @@ def get_application(config: Dict) -> FastAPI:
 Config._toml_file = f"{ROOTDIR}/config.toml"
 config = Config()
 
-setup_logger(config.api_mode)
+setup_logger(config.api_mode.CONFIG_NAME)
 app = get_application(config)


### PR DESCRIPTION
## Summary
- `setup_logger` was being called with the `Deployment` object instead of a string, so the `config_name == "prod"`/`"staging"` checks never matched and every environment ran at DEBUG level.
- Pass `config.api_mode.CONFIG_NAME` and update comparisons to the uppercased values (`"PROD"`, `"STAGE"`) that match the `constr(to_upper=True)` field.

## Test plan
- [ ] Start the app with `FASTAPI_ENV=PROD` and confirm only ERROR-and-above logs are emitted
- [ ] Start with `FASTAPI_ENV=STAGE` and confirm INFO-and-above logs are emitted
- [ ] Start with `FASTAPI_ENV=DEV` and confirm DEBUG logs are emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)