### PR TITLE
chore: improve developer ergonomics with Makefile and dep cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: help install test lint format run docker-build
+
+IMAGE ?= fastapi-api:latest
+FASTAPI_ENV ?= dev
+
+help:
+	@awk 'BEGIN {FS = ":.*##"; printf "Targets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  %-15s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+install: ## Sync dependencies (including dev)
+	uv sync
+
+test: ## Run the test suite with coverage
+	uv run pytest --verbose --cov=./
+
+lint: ## Lint the codebase with ruff
+	uv run ruff check .
+
+format: ## Format the codebase with ruff
+	uv run ruff format .
+	uv run ruff check --fix .
+
+run: ## Run the service locally
+	FASTAPI_ENV=$(FASTAPI_ENV) ./run_app.sh
+
+docker-build: ## Build the production Docker image
+	docker build -t "$(IMAGE)" . --build-arg FASTAPI_ENV=$(FASTAPI_ENV)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Simple fastapi skeleton for a stateless microservice (application for ml models,
 
 To run the service manually in debug mode install the required python dependencies:
 
-`uv install`
+`uv sync`
 
 You can run the service in debug mode:
 
@@ -15,11 +15,19 @@ export FASTAPI_ENV="dev"
 ./run_app.sh
 ```
 
+Or via the Makefile:
+
+```
+make run
+```
+
 ## Running service in Docker
 
 To build the Docker image:
 
-`docker build -t "fastapi-api:latest" . --build-arg FASTAPI_ENV=dev`
+`make docker-build`
+
+(equivalent to `docker build -t "fastapi-api:latest" . --build-arg FASTAPI_ENV=dev`)
 
 To run the Docker image:
 
@@ -51,4 +59,17 @@ Be aware, that OpenAPI schema doesn't support websockets.
 
 To run the tests:
 
-`uv run python -m pytest --verbose --cov=./`
+`make test`
+
+(equivalent to `uv run python -m pytest --verbose --cov=./`)
+
+## Lint and format
+
+```
+make lint
+make format
+```
+
+## Available make targets
+
+Run `make help` to see all available targets.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ readme = "README.md"
 requires-python = ">=3.12.8"
 dependencies = [
     "fastapi>=0.115.6",
-    "httpx>=0.28.1",
     "loguru>=0.7.3",
     "pydantic-settings>=2.7.1",
     "uvicorn[standard]>=0.34.0",
@@ -39,6 +38,7 @@ pythonpath = ["."]
 
 [dependency-groups]
 dev = [
+    "httpx>=0.28.1",
     "pytest>=8.3.4",
     "pytest-cov>=6.0.0",
     "ruff>=0.9.2",

--- a/uv.lock
+++ b/uv.lock
@@ -113,7 +113,6 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
-    { name = "httpx" },
     { name = "loguru" },
     { name = "pydantic-settings" },
     { name = "uvicorn", extra = ["standard"] },
@@ -122,6 +121,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -130,7 +130,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.6" },
-    { name = "httpx", specifier = ">=0.28.1" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "pydantic-settings", specifier = ">=2.7.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
@@ -139,6 +138,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.9.2" },


### PR DESCRIPTION
## Summary
- Add a `Makefile` with `help`, `install`, `test`, `lint`, `format`, `run`, and `docker-build` targets (with overridable `IMAGE` / `FASTAPI_ENV`).
- Move `httpx` out of runtime dependencies into the `dev` group — it is only pulled in by FastAPI's `TestClient`, so prod builds (`uv sync --no-dev`) no longer install it.
- Update README to use `uv sync` instead of the (non-existent) `uv install`, and point to the new `make` targets.

## Test plan
- [x] `uv sync --no-dev` no longer installs httpx
- [x] `make lint` passes
- [x] `make test` passes (1 test, 89% coverage)
- [x] `make help` lists all targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)