### PR TITLE
Fix run_app coverage target

### DIFF
--- a/run_app.sh
+++ b/run_app.sh
@@ -3,7 +3,7 @@
 if [ "$FASTAPI_ENV" = "PROD" ]; then
 	uv run uvicorn src.app.main:app --host 0.0.0.0 --port 5000 --workers 2 --log-level "error"
 elif [ "$FASTAPI_ENV" = "TEST" ]; then
-	uv run pytest --cov-report html --cov=app tests
+	uv run pytest --cov-report html --cov=src/app tests
 else
 	 uv run uvicorn src.app.main:app --host 0.0.0.0 --port 5000 --workers 1 --log-level "debug"
 fi


### PR DESCRIPTION
## Summary
- Update the FASTAPI_ENV=TEST path in run_app.sh to measure src/app instead of the nonexistent app module.
- Preserve the existing HTML coverage report behavior.

## Test Plan
- FASTAPI_ENV=TEST ./run_app.sh