### PR TITLE
Fail fast on invalid FASTAPI_ENV

### DIFF
--- a/src/app/config.py
+++ b/src/app/config.py
@@ -1,8 +1,8 @@
 import importlib.metadata
 from pathlib import Path
-from typing import Tuple, Type
+from typing import ClassVar, Tuple, Type
 
-from pydantic import BaseModel, Field, constr
+from pydantic import BaseModel, Field, constr, field_validator
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -27,6 +27,7 @@ class Deployment(BaseModel):
 
 class Config(BaseSettings):
     _toml_file: str = "config.toml"
+    VALID_FASTAPI_ENVS: ClassVar[tuple[str, ...]] = ("DEV", "PROD", "STAGE", "TEST")
 
     FASTAPI_ENV: constr(to_upper=True) = Field(default="DEV")
     BASEDIR: str = str(Path(__file__).resolve().parent)
@@ -39,6 +40,14 @@ class Config(BaseSettings):
     TEST: Deployment
 
     model_config = SettingsConfigDict(toml_file=[_toml_file], env_prefix="")
+
+    @field_validator("FASTAPI_ENV")
+    @classmethod
+    def validate_fastapi_env(cls, value: str) -> str:
+        if value not in cls.VALID_FASTAPI_ENVS:
+            expected = ", ".join(cls.VALID_FASTAPI_ENVS)
+            raise ValueError(f"Invalid FASTAPI_ENV {value!r}. Expected one of: {expected}")
+        return value
 
     @classmethod
     def settings_customise_sources(
@@ -55,5 +64,5 @@ class Config(BaseSettings):
         )
 
     @property
-    def api_mode(self) -> str:
-        return dict(self).get(self.FASTAPI_ENV)
+    def api_mode(self) -> Deployment:
+        return getattr(self, self.FASTAPI_ENV)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,7 @@
-from src.app.config import CORSConfig, Config
+import pytest
+from pydantic import ValidationError
+
+from src.app.config import CORSConfig, Config, Deployment
 
 
 def test_cors_config_defaults_disabled():
@@ -14,3 +17,29 @@ def test_deployment_has_default_cors_config():
     config = Config()
     assert config.DEV.cors.enabled is False
     assert config.PROD.cors.enabled is False
+
+
+def test_api_mode_returns_selected_deployment(monkeypatch):
+    monkeypatch.setenv("FASTAPI_ENV", "STAGE")
+    config = Config()
+
+    assert isinstance(config.api_mode, Deployment)
+    assert config.api_mode == config.STAGE
+
+
+def test_fastapi_env_normalizes_lowercase_before_api_mode_lookup(monkeypatch):
+    monkeypatch.setenv("FASTAPI_ENV", "stage")
+    config = Config()
+
+    assert config.FASTAPI_ENV == "STAGE"
+    assert config.api_mode == config.STAGE
+
+
+def test_invalid_fastapi_env_fails_during_config_construction(monkeypatch):
+    monkeypatch.setenv("FASTAPI_ENV", "bad")
+
+    with pytest.raises(
+        ValidationError,
+        match="Invalid FASTAPI_ENV 'BAD'. Expected one of: DEV, PROD, STAGE, TEST",
+    ):
+        Config()


### PR DESCRIPTION
## Summary
- Validate FASTAPI_ENV during Config construction and raise a clear Pydantic error for unsupported deployment names.
- Type Config.api_mode as Deployment and resolve it with attribute lookup after validation.
- Add tests for selected deployment resolution, lowercase env normalization, and invalid env failure.

## Tests
- uv run pytest -q
- uv run ruff check .