### PR TITLE
Add minimal CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --locked --dev
+
+      - name: Ruff check
+        run: uv run ruff check .
+
+      - name: Ruff format check
+        run: uv run ruff format --check .
+
+      - name: Tests
+        run: uv run pytest --verbose --cov=./
+
+      - name: Build package
+        run: uv build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -46,7 +46,9 @@ class Config(BaseSettings):
     def validate_fastapi_env(cls, value: str) -> str:
         if value not in cls.VALID_FASTAPI_ENVS:
             expected = ", ".join(cls.VALID_FASTAPI_ENVS)
-            raise ValueError(f"Invalid FASTAPI_ENV {value!r}. Expected one of: {expected}")
+            raise ValueError(
+                f"Invalid FASTAPI_ENV {value!r}. Expected one of: {expected}"
+            )
         return value
 
     @classmethod


### PR DESCRIPTION
## Summary
- Add a GitHub Actions CI workflow for the FastAPI skeleton.
- Run uv dependency sync, Ruff linting, Ruff format checks, pytest with coverage, and uv package build on PRs and pushes to main.
- Keep CI minimal by leaving Docker image builds out of the required workflow.

## Test Plan
- uv run ruff check .
- uv run ruff format --check .
- uv run pytest --verbose --cov=./
- uv build
- YAML parse check