### PR TITLE
Log websocket disconnects with structured fields

### DIFF
--- a/src/app/core/router.py
+++ b/src/app/core/router.py
@@ -70,5 +70,9 @@ async def health_ws(websocket: WebSocket) -> None:
 
             await asyncio.sleep(10)
 
-    except WebSocketDisconnect:
-        print("Client disconnected")
+    except WebSocketDisconnect as exc:
+        logger.bind(
+            event="websocket.disconnect",
+            path=websocket.url.path,
+            close_code=exc.code,
+        ).info("websocket disconnected")

--- a/src/app/v1/router.py
+++ b/src/app/v1/router.py
@@ -37,5 +37,9 @@ async def health_ws(websocket: WebSocket) -> None:
 
             await asyncio.sleep(10)
 
-    except WebSocketDisconnect:
-        print("Client disconnected")
+    except WebSocketDisconnect as exc:
+        logger.bind(
+            event="websocket.disconnect",
+            path=websocket.url.path,
+            close_code=exc.code,
+        ).info("websocket disconnected")

--- a/tests/test_websocket_logging.py
+++ b/tests/test_websocket_logging.py
@@ -1,0 +1,57 @@
+from types import SimpleNamespace
+
+import anyio
+import pytest
+from fastapi import WebSocketDisconnect
+
+from src.app.core import router as core_router
+from src.app.v1 import router as v1_router
+
+
+class DisconnectingWebSocket:
+    def __init__(self, path: str):
+        self.accepted = False
+        self.url = SimpleNamespace(path=path)
+        self.app = SimpleNamespace(state=SimpleNamespace(VERSION="test"))
+
+    async def accept(self):
+        self.accepted = True
+
+    async def send_json(self, data):
+        raise WebSocketDisconnect(code=1000)
+
+
+class RecordingLogger:
+    def __init__(self):
+        self.bind_kwargs = None
+        self.info_message = None
+
+    def bind(self, **kwargs):
+        self.bind_kwargs = kwargs
+        return self
+
+    def info(self, message):
+        self.info_message = message
+
+
+@pytest.mark.parametrize(
+    ("router_module", "path"),
+    [
+        (core_router, "/ws/health"),
+        (v1_router, "/v1/ws/health"),
+    ],
+)
+def test_websocket_disconnect_logs_structured_fields(monkeypatch, router_module, path):
+    websocket = DisconnectingWebSocket(path)
+    logger = RecordingLogger()
+    monkeypatch.setattr(router_module, "logger", logger)
+
+    anyio.run(router_module.health_ws, websocket)
+
+    assert websocket.accepted is True
+    assert logger.bind_kwargs == {
+        "event": "websocket.disconnect",
+        "path": path,
+        "close_code": 1000,
+    }
+    assert logger.info_message == "websocket disconnected"


### PR DESCRIPTION
## Summary
- Replace websocket disconnect print calls with Loguru structured info logs in core and v1 health websocket handlers.
- Include event, path, and close_code fields for disconnect log filtering.
- Add focused tests that exercise both disconnect handlers and assert the structured log payload.

## Test Plan
- uv run pytest --verbose --cov=./
- uv run ruff check .