### PR TITLE
Harden production runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,13 +65,22 @@ FROM python:3.12-slim AS runtime
 
 ENV LC_ALL=C.UTF-8 \
     LANG=C.UTF-8 \
-    PATH="/app/.venv/bin:$PATH"
+    PATH="/app/.venv/bin:$PATH" \
+    FASTAPI_ENV=PROD \
+    PORT=5000 \
+    WEB_CONCURRENCY=2
 
 WORKDIR /app
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
-COPY --from=build-prod /app /app
+RUN groupadd --gid 10001 app \
+    && useradd --uid 10001 --gid app --home-dir /app --no-create-home app
+
+COPY --from=build-prod --chown=app:app /app /app
+
+USER app:app
 
 EXPOSE 5000
 
-ENTRYPOINT ["bash", "./run_app.sh"]
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 CMD ["python", "-c", "import os, urllib.request; port = os.environ.get('PORT', '5000'); urllib.request.urlopen(f'http://127.0.0.1:{port}/health/live', timeout=2).read()"]
+
+ENTRYPOINT ["python", "-m", "src.app.runtime"]

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -46,7 +46,9 @@ class Config(BaseSettings):
     def validate_fastapi_env(cls, value: str) -> str:
         if value not in cls.VALID_FASTAPI_ENVS:
             expected = ", ".join(cls.VALID_FASTAPI_ENVS)
-            raise ValueError(f"Invalid FASTAPI_ENV {value!r}. Expected one of: {expected}")
+            raise ValueError(
+                f"Invalid FASTAPI_ENV {value!r}. Expected one of: {expected}"
+            )
         return value
 
     @classmethod

--- a/src/app/runtime.py
+++ b/src/app/runtime.py
@@ -1,0 +1,59 @@
+import os
+import sys
+from dataclasses import dataclass
+from typing import Mapping
+
+import uvicorn
+
+
+@dataclass(frozen=True)
+class RuntimeConfig:
+    port: int
+    workers: int
+
+
+class RuntimeConfigError(ValueError):
+    pass
+
+
+def _positive_int(env: Mapping[str, str], name: str, default: int) -> int:
+    raw_value = env.get(name, str(default))
+    try:
+        value = int(raw_value)
+    except ValueError as exc:
+        raise RuntimeConfigError(
+            f"{name} must be a positive integer, got {raw_value!r}"
+        ) from exc
+
+    if value < 1:
+        raise RuntimeConfigError(f"{name} must be a positive integer, got {raw_value!r}")
+
+    return value
+
+
+def get_runtime_config(env: Mapping[str, str] | None = None) -> RuntimeConfig:
+    runtime_env = os.environ if env is None else env
+    return RuntimeConfig(
+        port=_positive_int(runtime_env, "PORT", 5000),
+        workers=_positive_int(runtime_env, "WEB_CONCURRENCY", 2),
+    )
+
+
+def main() -> None:
+    try:
+        config = get_runtime_config()
+    except RuntimeConfigError as exc:
+        print(f"Runtime configuration error: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+
+    uvicorn.run(
+        "src.app.main:app",
+        host="0.0.0.0",
+        port=config.port,
+        workers=config.workers,
+        log_level="error",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/app/runtime.py
+++ b/src/app/runtime.py
@@ -26,7 +26,9 @@ def _positive_int(env: Mapping[str, str], name: str, default: int) -> int:
         ) from exc
 
     if value < 1:
-        raise RuntimeConfigError(f"{name} must be a positive integer, got {raw_value!r}")
+        raise RuntimeConfigError(
+            f"{name} must be a positive integer, got {raw_value!r}"
+        )
 
     return value
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -29,9 +29,7 @@ def test_runtime_config_reads_custom_values(monkeypatch):
         ("WEB_CONCURRENCY", "-1"),
     ],
 )
-def test_runtime_config_rejects_invalid_positive_ints(
-    monkeypatch, env_name, env_value
-):
+def test_runtime_config_rejects_invalid_positive_ints(monkeypatch, env_name, env_value):
     monkeypatch.setenv(env_name, env_value)
 
     with pytest.raises(

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,73 @@
+import pytest
+
+from src.app import runtime
+from src.app.runtime import RuntimeConfig, RuntimeConfigError, get_runtime_config
+
+
+def test_runtime_config_defaults(monkeypatch):
+    monkeypatch.delenv("PORT", raising=False)
+    monkeypatch.delenv("WEB_CONCURRENCY", raising=False)
+
+    assert get_runtime_config() == RuntimeConfig(port=5000, workers=2)
+
+
+def test_runtime_config_reads_custom_values(monkeypatch):
+    monkeypatch.setenv("PORT", "8080")
+    monkeypatch.setenv("WEB_CONCURRENCY", "4")
+
+    assert get_runtime_config() == RuntimeConfig(port=8080, workers=4)
+
+
+@pytest.mark.parametrize(
+    ("env_name", "env_value"),
+    [
+        ("PORT", "abc"),
+        ("PORT", "0"),
+        ("PORT", "-1"),
+        ("WEB_CONCURRENCY", "abc"),
+        ("WEB_CONCURRENCY", "0"),
+        ("WEB_CONCURRENCY", "-1"),
+    ],
+)
+def test_runtime_config_rejects_invalid_positive_ints(
+    monkeypatch, env_name, env_value
+):
+    monkeypatch.setenv(env_name, env_value)
+
+    with pytest.raises(
+        RuntimeConfigError, match=f"{env_name} must be a positive integer"
+    ):
+        get_runtime_config()
+
+
+def test_main_starts_uvicorn_with_runtime_config(monkeypatch):
+    calls = []
+    monkeypatch.setenv("PORT", "8080")
+    monkeypatch.setenv("WEB_CONCURRENCY", "1")
+    monkeypatch.setattr(
+        runtime.uvicorn, "run", lambda *args, **kwargs: calls.append((args, kwargs))
+    )
+
+    runtime.main()
+
+    assert calls == [
+        (
+            ("src.app.main:app",),
+            {
+                "host": "0.0.0.0",
+                "port": 8080,
+                "workers": 1,
+                "log_level": "error",
+            },
+        )
+    ]
+
+
+def test_main_exits_on_invalid_runtime_config(monkeypatch, capsys):
+    monkeypatch.setenv("PORT", "invalid")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runtime.main()
+
+    assert exc_info.value.code == 2
+    assert "PORT must be a positive integer" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- Harden the production Docker runtime to run as a non-root user without uv or shell startup.
- Add a Python runtime launcher with PORT and WEB_CONCURRENCY validation and direct uvicorn startup.
- Add a Docker healthcheck against /health/live and tests for runtime configuration.

## Test Plan
- uv run pytest
- uv run ruff check .
- docker build and default/custom PORT container smoke tests