### PR TITLE
Add developer onboarding files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Selects a deployment block from config.toml.
+# Valid values: DEV, STAGE, PROD, TEST
+FASTAPI_ENV=DEV
+
+# Local host port used by Docker Compose.
+PORT=5000

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install test lint format run docker-build
+.PHONY: help install test lint format run docker-build up down
 
 IMAGE ?= fastapi-api:latest
 FASTAPI_ENV ?= dev
@@ -24,3 +24,9 @@ run: ## Run the service locally
 
 docker-build: ## Build the production Docker image
 	docker build -t "$(IMAGE)" . --build-arg FASTAPI_ENV=$(FASTAPI_ENV)
+
+up: ## Run the service with Docker Compose
+	docker compose up --build
+
+down: ## Stop Docker Compose services
+	docker compose down

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Or via the Makefile:
 make run
 ```
 
+Local environment defaults are documented in `.env.example`.
+
 ## Running service in Docker
 
 To build the Docker image:
@@ -33,6 +35,18 @@ To run the Docker image:
 
 ```
 docker run -p 5000:5000 -ti fastapi-api:latest
+```
+
+Or run the service with Docker Compose:
+
+```
+make up
+```
+
+To stop the Compose services:
+
+```
+make down
 ```
 
 ## Local querying
@@ -73,3 +87,8 @@ make format
 ## Available make targets
 
 Run `make help` to see all available targets.
+
+## Developer onboarding
+
+See `docs/developer-onboarding.md` for local setup notes and the recipe for
+adding a new endpoint or shared resource.

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,10 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: runtime
+    environment:
+      FASTAPI_ENV: ${FASTAPI_ENV:-DEV}
+    ports:
+      - "${PORT:-5000}:5000"

--- a/docs/developer-onboarding.md
+++ b/docs/developer-onboarding.md
@@ -1,0 +1,128 @@
+# Developer onboarding
+
+This project is a small FastAPI skeleton for stateless services. The default
+local app port is `5000`.
+
+## Local setup
+
+Install dependencies:
+
+```bash
+uv sync
+```
+
+Run the service:
+
+```bash
+make run
+```
+
+Run checks:
+
+```bash
+make test
+make lint
+```
+
+`FASTAPI_ENV` selects a deployment block from `config.toml`. Valid values are
+`DEV`, `STAGE`, `PROD`, and `TEST`. Copy `.env.example` to `.env` when using
+Docker Compose locally; deployment settings such as `DEBUG` and CORS still live
+in `config.toml`.
+
+## Docker Compose
+
+Run the service with Compose:
+
+```bash
+make up
+```
+
+Stop the Compose services:
+
+```bash
+make down
+```
+
+Compose reads `.env` automatically when present. `PORT` changes the host port;
+the container still listens on port `5000`.
+
+## Add a new endpoint
+
+1. Add request and response models near the API version that owns the route,
+   usually in `src/app/v1/schema.py`.
+2. Add the route in `src/app/v1/router.py` using the shared `v1` router.
+3. Always set `response_model` so FastAPI validates and documents the response.
+4. Add focused tests for the route behavior and validation.
+
+Example:
+
+```python
+from pydantic import BaseModel
+
+
+class EchoRequest(BaseModel):
+    message: str
+
+
+class EchoResponse(BaseModel):
+    message: str
+```
+
+```python
+@v1.post("/echo", response_model=EchoResponse)
+def echo(payload: EchoRequest) -> EchoResponse:
+    return EchoResponse(message=payload.message)
+```
+
+## Add a shared resource
+
+Use the lifespan state for clients that need startup or shutdown, such as
+database pools, HTTP clients, or model clients.
+
+1. Create and attach the client in `src/app/lifespan.py` before `yield`.
+2. Store it on `app.state.resources.<name>`.
+3. Append async cleanup callables to `app.state._closers`.
+4. Append readiness checks to `app.state.readiness_checks`.
+5. Expose the resource through `src/app/dependencies.py`.
+6. In tests, override the dependency factory with `app.dependency_overrides`.
+
+Lifespan pattern:
+
+```python
+client = SomeClient(...)
+await client.connect()
+
+app.state.resources.some = client
+app.state._closers.append(client.aclose)
+app.state.readiness_checks.append(("some", client.ping))
+```
+
+Dependency pattern:
+
+```python
+from typing import Annotated
+
+from fastapi import Depends, Request
+
+
+def get_some_client(request: Request) -> SomeClient:
+    return request.app.state.resources.some
+
+
+SomeClientDep = Annotated[SomeClient, Depends(get_some_client)]
+```
+
+Router usage:
+
+```python
+@v1.get("/items/{item_id}", response_model=ItemResponse)
+async def get_item(item_id: str, client: SomeClientDep) -> ItemResponse:
+    item = await client.get(item_id)
+    return ItemResponse.model_validate(item)
+```
+
+Test override:
+
+```python
+app.dependency_overrides[get_some_client] = lambda: fake_client
+```


### PR DESCRIPTION
## Summary
Add .env.example and a minimal Docker Compose setup for local development.
Document local setup, Compose usage, and recipes for adding endpoints and shared resources.
Expose make up and make down as wrappers around Docker Compose.

## Test Plan
- make help
- docker compose config
- uv run pytest -v