### PR TITLE
Document observability and runtime settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ FASTAPI_ENV=DEV
 
 # Local host port used by Docker Compose.
 PORT=5000
+
+# Uvicorn worker count used by the container runtime.
+WEB_CONCURRENCY=2

--- a/README.md
+++ b/README.md
@@ -37,11 +37,29 @@ To run the Docker image:
 docker run -p 5000:5000 -ti fastapi-api:latest
 ```
 
+Runtime settings are read from environment variables:
+
+- `PORT` controls the uvicorn listen port inside the container. It defaults to
+  `5000` and must be a positive integer.
+- `WEB_CONCURRENCY` controls the uvicorn worker count. It defaults to `2` and
+  must be a positive integer.
+
+For direct `docker run`, keep the host/container port mapping aligned with
+`PORT` when you change it:
+
+```
+docker run -e PORT=8080 -e WEB_CONCURRENCY=4 -p 8080:8080 -ti fastapi-api:latest
+```
+
 Or run the service with Docker Compose:
 
 ```
 make up
 ```
+
+Compose reads `.env` automatically. In Compose, `PORT` changes only the host
+port mapped to container port `5000`; the container still listens on `5000`.
+`WEB_CONCURRENCY` is passed through to the container worker count.
 
 To stop the Compose services:
 
@@ -63,6 +81,32 @@ For the websockets endpoint, run:
 
 `websocat ws://127.0.0.1:5000/v1/ws/health`
 
+## Observability
+
+The service emits structured JSON request logs. Each completed HTTP request
+logs one record with `message="request"` plus `method`, `path`, `status`,
+`duration_ms`, and `request_id`. When tracing is enabled and a span is active,
+the request log also includes `trace_id` and `span_id`.
+
+Incoming `X-Request-ID` values are echoed on the response. If the request does
+not provide one, the service generates an ID and returns it as `X-Request-ID`.
+Responses also include `X-Process-Time`, measured in seconds.
+
+Prometheus and tracing are disabled by default and are enabled per deployment
+block in `config.toml`:
+
+```toml
+[DEV.observability.prometheus]
+enabled = true
+path = "/metrics"
+
+[DEV.observability.tracing]
+enabled = true
+service_name = "fastapi_skeleton"
+```
+
+Prometheus exposes metrics at the configured path, defaulting to `/metrics`.
+Tracing uses the configured `service_name` as the OpenTelemetry service name.
 
 ## API Documentation
 

--- a/compose.yml
+++ b/compose.yml
@@ -6,5 +6,6 @@ services:
       target: runtime
     environment:
       FASTAPI_ENV: ${FASTAPI_ENV:-DEV}
+      WEB_CONCURRENCY: ${WEB_CONCURRENCY:-2}
     ports:
       - "${PORT:-5000}:5000"

--- a/docs/developer-onboarding.md
+++ b/docs/developer-onboarding.md
@@ -75,6 +75,11 @@ port `5000` by default.
 Docker Compose locally; deployment settings such as `DEBUG` and CORS still live
 in `config.toml`.
 
+`PORT` and `WEB_CONCURRENCY` are process runtime settings consumed by
+`src/app/runtime.py` when the container entrypoint starts uvicorn. Both must be
+positive integers. Invalid values print a runtime configuration error to stderr
+and exit with status `2`.
+
 ## Docker Compose
 
 Run the service with Compose:
@@ -90,7 +95,10 @@ make down
 ```
 
 Compose reads `.env` automatically when present. `PORT` changes the host port;
-the container still listens on port `5000`.
+the container still listens on port `5000`. `WEB_CONCURRENCY` is passed through
+to the container and controls uvicorn worker count. The Dockerfile defaults are
+`FASTAPI_ENV=PROD`, `PORT=5000`, and `WEB_CONCURRENCY=2`; Compose overrides
+`FASTAPI_ENV` to `${FASTAPI_ENV:-DEV}` for local development.
 
 ## Add a new endpoint
 
@@ -204,7 +212,10 @@ method, path, status, duration_ms, request_id, trace_id, span_id
 ```
 
 The JSON sink lives in `src/app/logging.py:39`. `trace_id` and `span_id` are
-populated from the active OTel span when tracing is enabled. On unhandled
+populated only when the current request has an active, valid OTel span. Those
+fields are absent when tracing is disabled or no span is active. The log
+fields come from `RequestTimer` and the request id ContextVar, then
+`sink_serializer` merges `record["extra"]` into the emitted JSON. On unhandled
 exceptions the timer logs `status=500` and re-raises so the registered
 exception handlers still run.
 
@@ -262,12 +273,28 @@ are mounted and toggles two independent features from the config block:
 - **Prometheus** — registers a private `CollectorRegistry` with
   `http_requests_total` (Counter) and `http_request_duration_seconds`
   (Histogram), both labelled `(method, path, status)` where `path` is the
-  matched route template to bound cardinality. Exposes the registry at the
-  configured `metrics` path (default `/metrics`), excluded from OpenAPI.
+  matched route template to bound cardinality. Unknown routes fall back to the
+  raw request path. The metrics endpoint itself is skipped by the middleware so
+  scrapes do not count as app traffic. Exposes the registry at the configured
+  `metrics` path (default `/metrics`), excluded from OpenAPI.
 - **OTel tracing** — installs a `TracerProvider` with `service.name` from
-  config (only if one isn't already set) and calls
+  config only when the global provider is still OpenTelemetry's proxy provider,
+  then calls
   `FastAPIInstrumentor().instrument_app(app)`, producing one span per
   request. The request log automatically picks up `trace_id`/`span_id`.
+
+Prometheus and tracing are both disabled by default. Enable them per deployment
+block in `config.toml`:
+
+```toml
+[DEV.observability.prometheus]
+enabled = true
+path = "/metrics"
+
+[DEV.observability.tracing]
+enabled = true
+service_name = "fastapi_skeleton"
+```
 
 ### Routing
 


### PR DESCRIPTION
## Summary
- Documents structured request logs, request/timing headers, Prometheus, tracing, and runtime environment settings in the README.
- Expands developer onboarding with runtime validation, Docker/Compose defaults, middleware logging details, metric labels, and tracing provider behavior.
- Adds WEB_CONCURRENCY to the example environment and passes it through Docker Compose.

## Test Plan
- uv run ruff check .
- make test